### PR TITLE
keep entries for directories

### DIFF
--- a/src/main/java/com/github/manouti/normalize/DefaultNormalizer.java
+++ b/src/main/java/com/github/manouti/normalize/DefaultNormalizer.java
@@ -67,10 +67,11 @@ public class DefaultNormalizer implements Normalizer {
 					manifestTransformer.normalizeManifest(jarOutputStream, jar, entry, timestamp);
 				} else if(resource.endsWith("/pom.properties")) {
 					pomPropertiesTransformer.normalizePropertiesFile(jarOutputStream, jar, entry, timestamp);
-				} else if (!entry.isDirectory()) {
-					InputStream inputStream = jar.getInputStream(entry);
-					jarOutputStream.putNextEntry(entry);
-					IOUtil.copy(inputStream, jarOutputStream);
+				} else {
+						InputStream inputStream = jar.getInputStream(entry);
+						jarOutputStream.putNextEntry(entry);
+					if (!entry.isDirectory())
+						IOUtil.copy(inputStream, jarOutputStream);
 				}
 			}
 		} catch (Throwable th) {


### PR DESCRIPTION
This fixes a bug I had where I had an uber-jar with Spark which could not find it's static web resources.

```
java.lang.Exception: Could not find resource path for Web UI: org/apache/spark/ui/static
```

My guess is that you can search resources for directories, and when normalize omits these jar entries, you have a problem.
